### PR TITLE
Set environment variables using ENV rather than bashrc.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ RUN mv /initXETemp.ora /u01/app/oracle/product/11.2.0/xe/config/scripts
 
 RUN printf 8080\\n1521\\noracle\\noracle\\ny\\n | /etc/init.d/oracle-xe configure
 
-RUN echo 'export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe' >> /etc/bash.bashrc
-RUN echo 'export PATH=$ORACLE_HOME/bin:$PATH' >> /etc/bash.bashrc
-RUN echo 'export ORACLE_SID=XE' >> /etc/bash.bashrc
+ENV ORACLE_HOME /u01/app/oracle/product/11.2.0/xe
+ENV PATH /u01/app/oracle/product/11.2.0/xe/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
+ENV ORACLE_SID XE
 
 EXPOSE 22
 EXPOSE 1521


### PR DESCRIPTION
This method of setting environment variables should be more reliable.
Docker will set them even when you override the command to execute and
try to execute something other than a bash shell (e.g., sqlplus).
