### PR TITLE
Allow sql scripts and shell commands to be run on startup

### DIFF
--- a/assets/setup.sh
+++ b/assets/setup.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-# avoid dpkg frontend dialog / frontend warnings 
+# avoid dpkg frontend dialog / frontend warnings
 export DEBIAN_FRONTEND=noninteractive
 
 cat /assets/oracle-xe_11.2.0-1.0_amd64.deba* > /assets/oracle-xe_11.2.0-1.0_amd64.deb
 
 # Install OpenSSH
+apt-get update
 apt-get install -y openssh-server &&
 mkdir /var/run/sshd &&
 echo 'root:admin' | chpasswd &&

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -8,10 +8,10 @@ sed -i "s/%port%/1521/g" "${LISTENERS_ORA}" &&
 service oracle-xe start
 
 export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
+export PATH=$ORACLE_HOME/bin:$PATH
+export ORACLE_SID=XE
 
 if [ "$ORACLE_ALLOW_REMOTE" = true ]; then
-  export PATH=$ORACLE_HOME/bin:$PATH
-  export ORACLE_SID=XE
   echo "alter system disable restricted session;" | sqlplus -s SYSTEM/oracle
 fi
 

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -7,9 +7,19 @@ sed -i "s/%port%/1521/g" "${LISTENERS_ORA}" &&
 
 service oracle-xe start
 
+export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
+
 if [ "$ORACLE_ALLOW_REMOTE" = true ]; then
-  export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
   export PATH=$ORACLE_HOME/bin:$PATH
   export ORACLE_SID=XE
   echo "alter system disable restricted session;" | sqlplus -s SYSTEM/oracle
 fi
+
+for f in /docker-entrypoint-initdb.d/*; do
+  case "$f" in
+    *.sh)     echo "$0: running $f"; . "$f" ;;
+    *.sql)    echo "$0: running $f"; echo "exit" | /u01/app/oracle/product/11.2.0/xe/bin/sqlplus "SYSTEM/oracle" @"$f"; echo ;;
+    *)        echo "$0: ignoring $f" ;;
+  esac
+  echo
+done


### PR DESCRIPTION
Following the pattern from Postgres, this will allow commands (eg adduser scripts) to be run at database startup time if they're placed in ./docker-entrypoint-initdb.d/