### PR TITLE
Add volume support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ MAINTAINER Wei-Ming Wu <wnameless@gmail.com>
 ADD assets /assets
 RUN /assets/setup.sh
 
+RUN mv /u01/app/oracle/oradata /u01/app/oracle/oradata.orig
+VOLUME /u01/app/oracle/oradata
+
 EXPOSE 22
 EXPOSE 1521
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Run this, if you want the database to be connected remotely:
 docker run -d -p 49160:22 -p 49161:1521 -e ORACLE_ALLOW_REMOTE=true wnameless/oracle-xe-11g
 ```
 
+Run this to store data in a volume outside the docker container:
+```
+docker run -d -p 49160:22 -p 49161:1521 -v /my/data/folder:/u01/app/oracle/oradata wnameless/oracle-xe-11g
+```
+
 Connect database with following setting:
 ```
 hostname: localhost

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+
+# Initialize the host's data volume, leaving a trace when finished.
+if [ ! -e /u01/app/oracle/oradata/dataloaded ]
+then
+  cp -r /u01/app/oracle/oradata.orig/* /u01/app/oracle/oradata/
+  touch /u01/app/oracle/oradata/dataloaded
+  echo "Host data volume was initialized."
+else
+  echo "Data was loaded from the host."
+fi
+
 LISTENER_ORA=/u01/app/oracle/product/11.2.0/xe/network/admin/listener.ora
 TNSNAMES_ORA=/u01/app/oracle/product/11.2.0/xe/network/admin/tnsnames.ora
 


### PR DESCRIPTION
Added support for storing data on the host machine to persist data beyond the life of the container. After setup.sh is run, the contents of oradata are moved into a temporary directory. The volume is then created. 

On first startup, the oradata contents are copied into the volume and a marker file `dataloaded` is created. 

On subsequent startups, if `dataloaded` is found, it assumes the data is valid and uses the data from the volume. 