### PR TITLE
run scripts in docker-entrypoint-initdb.d as SYSDBA

### DIFF
--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -22,7 +22,7 @@ fi
 for f in /docker-entrypoint-initdb.d/*; do
   case "$f" in
     *.sh)     echo "$0: running $f"; . "$f" ;;
-    *.sql)    echo "$0: running $f"; echo "exit" | /u01/app/oracle/product/11.2.0/xe/bin/sqlplus "SYSTEM/oracle" @"$f"; echo ;;
+    *.sql)    echo "$0: running $f"; echo "exit" | /u01/app/oracle/product/11.2.0/xe/bin/sqlplus "SYS/oracle" AS SYSDBA @"$f"; echo ;;
     *)        echo "$0: ignoring $f" ;;
   esac
   echo


### PR DESCRIPTION
Using a script in docker-entrypoint-initdb.d to install DBMS_CRYPTO package causes errors because its not installed as SYSDBA. Wouldnt it be preferable to run these scripts as SYSDBA?