### PR TITLE
Eliminate misleading initialization message

### DIFF
--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -30,6 +30,7 @@ if [ "$ORACLE_DISABLE_ASYNCH_IO" = true ]; then
 fi
 
 for f in /docker-entrypoint-initdb.d/*; do
+  [ -f "$f" ] || continue
   case "$f" in
     *.sh)     echo "$0: running $f"; . "$f" ;;
     *.sql)    echo "$0: running $f"; echo "exit" | /u01/app/oracle/product/11.2.0/xe/bin/sqlplus "SYS/oracle" AS SYSDBA @"$f"; echo ;;


### PR DESCRIPTION
When the container starts, the following output is produced:
```
Starting Oracle Net Listener.
Starting Oracle Database 11g Express Edition instance.

/usr/sbin/startup.sh: ignoring /docker-entrypoint-initdb.d/*
```

It looks like it ignores the entire init directory, however, it only means that it's empty, and the `*` symbol in the `for` loop is not resolved to any list of files, therefore it's used as is and is ignored since it's not a `*.sh` or `*.sql` file.

With the fix, the script will ignore the unresolved wildcard.