### PR TITLE
Adding Dockerfile Best Practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:18.04
 
-MAINTAINER Wei-Ming Wu <wnameless@gmail.com>
-
 COPY assets /assets
 RUN /assets/setup.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 MAINTAINER Wei-Ming Wu <wnameless@gmail.com>
 
-ADD assets /assets
+COPY assets /assets
 RUN /assets/setup.sh
 
 EXPOSE 22


### PR DESCRIPTION
- MAINTAINER is deprecated since Docker 1.13.0
- Use COPY instead of ADD for files and folders