### PR TITLE
Abort on errors

### DIFF
--- a/assets/setup.sh
+++ b/assets/setup.sh
@@ -1,36 +1,37 @@
 #!/bin/bash
+set -Eeuo pipefail
 
 # avoid dpkg frontend dialog / frontend warnings
 export DEBIAN_FRONTEND=noninteractive
 
 # Prepare to install Oracle
-apt-get update &&
-apt-get install -y libaio1 net-tools bc &&
-ln -s /usr/bin/awk /bin/awk &&
-mkdir /var/lock/subsys &&
-mv /assets/chkconfig /sbin/chkconfig &&
-chmod 755 /sbin/chkconfig &&
+apt-get update
+apt-get install -y libaio1 net-tools bc
+ln -s /usr/bin/awk /bin/awk
+mkdir /var/lock/subsys
+mv /assets/chkconfig /sbin/chkconfig
+chmod 755 /sbin/chkconfig
 
 # Install Oracle
-cat /assets/oracle-xe_11.2.0-1.0_amd64.deba* > /assets/oracle-xe_11.2.0-1.0_amd64.deb &&
-dpkg --install /assets/oracle-xe_11.2.0-1.0_amd64.deb &&
+cat /assets/oracle-xe_11.2.0-1.0_amd64.deba* > /assets/oracle-xe_11.2.0-1.0_amd64.deb
+dpkg --install /assets/oracle-xe_11.2.0-1.0_amd64.deb
 
 # Backup listener.ora as template
-cp /u01/app/oracle/product/11.2.0/xe/network/admin/listener.ora /u01/app/oracle/product/11.2.0/xe/network/admin/listener.ora.tmpl &&
-cp /u01/app/oracle/product/11.2.0/xe/network/admin/tnsnames.ora /u01/app/oracle/product/11.2.0/xe/network/admin/tnsnames.ora.tmpl &&
+cp /u01/app/oracle/product/11.2.0/xe/network/admin/listener.ora /u01/app/oracle/product/11.2.0/xe/network/admin/listener.ora.tmpl
+cp /u01/app/oracle/product/11.2.0/xe/network/admin/tnsnames.ora /u01/app/oracle/product/11.2.0/xe/network/admin/tnsnames.ora.tmpl
 
-mv /assets/init.ora /u01/app/oracle/product/11.2.0/xe/config/scripts &&
-mv /assets/initXETemp.ora /u01/app/oracle/product/11.2.0/xe/config/scripts &&
+mv /assets/init.ora /u01/app/oracle/product/11.2.0/xe/config/scripts
+mv /assets/initXETemp.ora /u01/app/oracle/product/11.2.0/xe/config/scripts
 
-printf 8080\\n1521\\noracle\\noracle\\ny\\n | /etc/init.d/oracle-xe configure &&
+printf 8080\\n1521\\noracle\\noracle\\ny\\n | /etc/init.d/oracle-xe configure
 
-echo 'export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe' >> /etc/bash.bashrc &&
-echo 'export PATH=$ORACLE_HOME/bin:$PATH' >> /etc/bash.bashrc &&
-echo 'export ORACLE_SID=XE' >> /etc/bash.bashrc &&
+echo 'export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe' >> /etc/bash.bashrc
+echo 'export PATH=$ORACLE_HOME/bin:$PATH' >> /etc/bash.bashrc
+echo 'export ORACLE_SID=XE' >> /etc/bash.bashrc
 
 # Install startup script for container
-mv /assets/startup.sh /usr/sbin/startup.sh &&
-chmod +x /usr/sbin/startup.sh &&
+mv /assets/startup.sh /usr/sbin/startup.sh
+chmod +x /usr/sbin/startup.sh
 
 # Create initialization script folders
 mkdir /docker-entrypoint-initdb.d

--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
+set -Eeuo pipefail
 LISTENER_ORA=/u01/app/oracle/product/11.2.0/xe/network/admin/listener.ora
 TNSNAMES_ORA=/u01/app/oracle/product/11.2.0/xe/network/admin/tnsnames.ora
 
-cp "${LISTENER_ORA}.tmpl" "$LISTENER_ORA" &&
-sed -i "s/%hostname%/$HOSTNAME/g" "${LISTENER_ORA}" &&
-sed -i "s/%port%/1521/g" "${LISTENER_ORA}" &&
-cp "${TNSNAMES_ORA}.tmpl" "$TNSNAMES_ORA" &&
-sed -i "s/%hostname%/$HOSTNAME/g" "${TNSNAMES_ORA}" &&
-sed -i "s/%port%/1521/g" "${TNSNAMES_ORA}" &&
+cp "${LISTENER_ORA}.tmpl" "$LISTENER_ORA"
+sed -i "s/%hostname%/$HOSTNAME/g" "${LISTENER_ORA}"
+sed -i "s/%port%/1521/g" "${LISTENER_ORA}"
+cp "${TNSNAMES_ORA}.tmpl" "$TNSNAMES_ORA"
+sed -i "s/%hostname%/$HOSTNAME/g" "${TNSNAMES_ORA}"
+sed -i "s/%port%/1521/g" "${TNSNAMES_ORA}"
 
 service oracle-xe start
 


### PR DESCRIPTION
If an error occurs, stop with an error.

This ensure that unexpected errors stop execution instead of allowing startup to proceed with an unknown/unexpected state.