### PR TITLE
Echo "DATABASE IS READY TO USE!" when ready

### DIFF
--- a/assets/startup.sh
+++ b/assets/startup.sh
@@ -38,3 +38,7 @@ for f in /docker-entrypoint-initdb.d/*; do
   esac
   echo
 done
+
+echo "#########################"
+echo "DATABASE IS READY TO USE!"
+echo "#########################"


### PR DESCRIPTION
This message is the same as what Oracle's image displays, allowing other programs that look for this message to find it making this image compatible with Oracle's.

See https://github.com/oracle/docker-images/blob/8310e137151d93b05b051d91ec3acf6049e3df94/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh#L193

An example of something that looks for this message is Spring Session JDBC:
https://github.com/spring-projects/spring-session/blob/2.2.0.RC1/spring-session-jdbc/src/integration-test/java/org/springframework/session/jdbc/DatabaseContainers.java#L161